### PR TITLE
feat(钉钉): 新增直接跳转考勤打卡界面功能

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,3 +72,4 @@ lint/tmp/
 # lint/reports/
 
 /apk
+*.md

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -77,6 +77,7 @@ android {
     buildFeatures {
         buildConfig true
         viewBinding true
+        buildConfig true
     }
 
     applicationVariants.configureEach {

--- a/app/src/main/java/com/pengxh/daily/app/extensions/Context.kt
+++ b/app/src/main/java/com/pengxh/daily/app/extensions/Context.kt
@@ -1,15 +1,19 @@
 package com.pengxh.daily.app.extensions
 
+import android.annotation.SuppressLint
+import android.content.ActivityNotFoundException
 import android.content.ComponentName
 import android.content.Context
 import android.content.Intent
 import android.content.pm.PackageManager
+import android.net.Uri
 import android.os.Build
 import android.util.Log
 import androidx.core.app.NotificationManagerCompat
 import com.pengxh.daily.app.utils.ApplicationEvent
 import com.pengxh.daily.app.utils.Constant
 import com.pengxh.kt.lite.extensions.show
+import com.pengxh.kt.lite.utils.SaveKeyValues
 import org.greenrobot.eventbus.EventBus
 
 /**
@@ -50,7 +54,21 @@ fun Context.openApplication(needCountDown: Boolean) {
         return
     }
 
-    // 跳转目标应用
+    // 钉钉且用户开启了"直接跳转打卡界面"，走 scheme 落地到考勤 H5
+    val directAttendance = SaveKeyValues.getValue(Constant.DIRECT_ATTENDANCE_KEY, false) as Boolean
+    if (targetApp == Constant.DING_DING && directAttendance) {
+        val launched = tryOpenDingTalkAttendance()
+        if (launched) {
+            if (needCountDown) {
+                EventBus.getDefault().post(ApplicationEvent.StartCountdownTime(false))
+            }
+            return
+        }
+        // scheme 失败则 fallback 到 Launcher
+        Log.w("Ex-Context", "openApplication: 钉钉打卡 scheme 失败，回退到 Launcher")
+    }
+
+    // 通用：跳转目标应用 Launcher Activity
     val intent = Intent(Intent.ACTION_MAIN, null).apply {
         addCategory(Intent.CATEGORY_LAUNCHER)
         addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
@@ -82,7 +100,18 @@ fun Context.openApplication() {
         return
     }
 
-    // 跳转目标应用
+    // 钉钉且用户开启了"直接跳转打卡界面"，走 scheme 落地到考勤 H5
+    val directAttendance = SaveKeyValues.getValue(Constant.DIRECT_ATTENDANCE_KEY, false) as Boolean
+    if (targetApp == Constant.DING_DING && directAttendance) {
+        val launched = tryOpenDingTalkAttendance()
+        if (launched) {
+            EventBus.getDefault().post(ApplicationEvent.StartCountdownTime(true))
+            return
+        }
+        Log.w("Ex-Context", "openApplication: 钉钉打卡 scheme 失败，回退到 Launcher")
+    }
+
+    // 通用：跳转目标应用 Launcher Activity
     val intent = Intent(Intent.ACTION_MAIN, null).apply {
         addCategory(Intent.CATEGORY_LAUNCHER)
         addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
@@ -102,5 +131,25 @@ fun Context.openApplication() {
         EventBus.getDefault().post(ApplicationEvent.StartCountdownTime(true))
     } else {
         Log.w("Ex-Context", "openApplication: 未找到目标应用的 Launcher Activity，包名：$targetApp")
+    }
+}
+
+/**
+ * 通过 scheme 直接跳转钉钉考勤打卡页
+ * @return true 表示 scheme 启动成功
+ */
+@SuppressLint("UseKtx")
+private fun Context.tryOpenDingTalkAttendance(): Boolean {
+    return try {
+        val uri = Uri.parse("dingtalk://dingtalkclient/page/link?url=https://attend.dingtalk.com/attend/index.html")
+        val intent = Intent(Intent.ACTION_VIEW, uri).apply {
+            addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+        }
+        startActivity(intent)
+        Log.d("Ex-Context", "tryOpenDingTalkAttendance: scheme 启动成功")
+        true
+    } catch (e: ActivityNotFoundException) {
+        Log.w("Ex-Context", "tryOpenDingTalkAttendance: scheme 不可用 -> ${e.message}")
+        false
     }
 }

--- a/app/src/main/java/com/pengxh/daily/app/ui/SettingsActivity.kt
+++ b/app/src/main/java/com/pengxh/daily/app/ui/SettingsActivity.kt
@@ -89,6 +89,7 @@ class SettingsActivity : KotlinBaseActivity<ActivitySettingsBinding>() {
 
         val index = SaveKeyValues.getValue(Constant.TARGET_APP_KEY, 0) as Int
         binding.iconView.setBackgroundResource(icons[index])
+        updateDirectAttendanceVisibility(index)
 
         binding.appVersion.text = BuildConfig.VERSION_NAME
         if (notificationEnable()) {
@@ -208,6 +209,7 @@ class SettingsActivity : KotlinBaseActivity<ActivitySettingsBinding>() {
                         // 更新配置
                         binding.iconView.setBackgroundResource(icons[position])
                         SaveKeyValues.putValue(Constant.TARGET_APP_KEY, position)
+                        updateDirectAttendanceVisibility(position)
                     }
                 }).build().show()
         }
@@ -298,6 +300,10 @@ class SettingsActivity : KotlinBaseActivity<ActivitySettingsBinding>() {
             EventBus.getDefault().post(ApplicationEvent.CaptureScreen)
         }
 
+        binding.directAttendanceCheckBox.setOnCheckedChangeListener { _, isChecked ->
+            SaveKeyValues.putValue(Constant.DIRECT_ATTENDANCE_KEY, isChecked)
+        }
+
         binding.gestureDetectSwitch.setOnCheckedChangeListener { _, isChecked ->
             SaveKeyValues.putValue(Constant.GESTURE_DETECTOR_KEY, isChecked)
         }
@@ -383,6 +389,8 @@ class SettingsActivity : KotlinBaseActivity<ActivitySettingsBinding>() {
             }
         }
 
+        binding.directAttendanceCheckBox.isChecked =
+            SaveKeyValues.getValue(Constant.DIRECT_ATTENDANCE_KEY, false) as Boolean
         binding.gestureDetectSwitch.isChecked =
             SaveKeyValues.getValue(Constant.GESTURE_DETECTOR_KEY, true) as Boolean
         binding.backToHomeSwitch.isChecked =
@@ -443,6 +451,15 @@ class SettingsActivity : KotlinBaseActivity<ActivitySettingsBinding>() {
                 e.printStackTrace()
             }
         }
+    }
+
+    /**
+     * 仅钉钉时显示"直接跳转打卡界面"选项
+     */
+    private fun updateDirectAttendanceVisibility(targetIndex: Int) {
+        val visibility = if (targetIndex == 0) View.VISIBLE else View.GONE
+        binding.directAttendanceLayout.visibility = visibility
+        binding.directAttendanceDivider.visibility = visibility
     }
 
     override fun onDestroy() {

--- a/app/src/main/java/com/pengxh/daily/app/utils/Constant.kt
+++ b/app/src/main/java/com/pengxh/daily/app/utils/Constant.kt
@@ -24,6 +24,7 @@ object Constant {
     const val WX_WEB_HOOK_KEY = "WX_WEB_HOOK_KEY"
     const val CHANNEL_TYPE_KEY = "CHANNEL_TYPE_KEY"
     const val RESULT_SOURCE_KEY = "RESULT_SOURCE_KEY"
+    const val DIRECT_ATTENDANCE_KEY = "DIRECT_ATTENDANCE_KEY"
 
     // ============================================================
     // 目标应用

--- a/app/src/main/res/layout/activity_settings.xml
+++ b/app/src/main/res/layout/activity_settings.xml
@@ -414,6 +414,38 @@
                     android:background="#CCC" />
 
                 <RelativeLayout
+                    android:id="@+id/directAttendanceLayout"
+                    android:layout_width="match_parent"
+                    android:layout_height="@dimen/itemLayoutHeight"
+                    android:background="@drawable/bg_solid_layout_white_16"
+                    android:paddingHorizontal="@dimen/dp_16"
+                    android:visibility="gone">
+
+                    <com.google.android.material.textview.MaterialTextView
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_centerVertical="true"
+                        android:text="直接跳转钉钉考勤界面"
+                        android:textColor="@color/text_default_color"
+                        android:textSize="@dimen/sp_16" />
+
+                    <com.google.android.material.switchmaterial.SwitchMaterial
+                        android:id="@+id/directAttendanceCheckBox"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_alignParentEnd="true"
+                        android:layout_centerVertical="true" />
+                </RelativeLayout>
+
+                <View
+                    android:id="@+id/directAttendanceDivider"
+                    android:layout_width="match_parent"
+                    android:layout_height="1px"
+                    android:layout_marginHorizontal="@dimen/dp_16"
+                    android:background="#CCC"
+                    android:visibility="gone" />
+
+                <RelativeLayout
                     android:id="@+id/captureTestLayout"
                     android:layout_width="match_parent"
                     android:layout_height="@dimen/itemLayoutHeight"


### PR DESCRIPTION
- 新增 DIRECT_ATTENDANCE_KEY 常量用于持久化开关状态
- Context 扩展：检测钉钉+开关开启时，通过 scheme 直接落地考勤 H5，失败则 fallback 到 Launcher
- SettingsActivity：新增直接打卡开关，仅选择钉钉时可见
- activity_settings.xml：新增对应 UI 布局（SwitchMaterial + 分割线）
- .gitignore：新增忽略 *.md 文件