### PR TITLE
fix(core): 修复任务运行状态管理与多个体验问题

### DIFF
--- a/app/src/main/java/com/pengxh/daily/app/adapter/DailyTaskAdapter.kt
+++ b/app/src/main/java/com/pengxh/daily/app/adapter/DailyTaskAdapter.kt
@@ -24,17 +24,21 @@ class DailyTaskAdapter(private val dataBeans: MutableList<DailyTaskBean>) :
     private var onItemClickListener: OnItemClickListener? = null
 
     fun updateCurrentTaskState(position: Int) {
-        this.mPosition = position
-        notifyDataSetChanged()
+        val oldPosition = mPosition
+        mPosition = position
+        if (oldPosition >= 0 && oldPosition < dataBeans.size) notifyItemChanged(oldPosition)
+        if (position >= 0 && position < dataBeans.size) notifyItemChanged(position)
     }
 
     fun updateCurrentTaskState(position: Int, actualTime: String) {
-        this.mPosition = position
+        if (position < 0 || position >= dataBeans.size) return
+        val oldPosition = mPosition
+        mPosition = position
         this.actualTime = actualTime
-        if (position < 0 || position >= dataBeans.size) {
-            return
+        if (oldPosition >= 0 && oldPosition < dataBeans.size && oldPosition != position) {
+            notifyItemChanged(oldPosition)
         }
-        notifyDataSetChanged()
+        notifyItemChanged(position)
     }
 
     override fun getItemCount(): Int = dataBeans.size

--- a/app/src/main/java/com/pengxh/daily/app/retrofit/RetrofitServiceManager.kt
+++ b/app/src/main/java/com/pengxh/daily/app/retrofit/RetrofitServiceManager.kt
@@ -32,7 +32,17 @@ object RetrofitServiceManager {
     }
 
     suspend fun sendImageMessage(imagePath: String): String {
-        val imageBytes = File(imagePath).readBytes()
+        val file = File(imagePath)
+        // 微信群机器人图片消息限制 2MB
+        val maxBytes = 2 * 1024 * 1024L
+        if (!file.exists()) {
+            return sendMessage("截图发送失败：图片文件不存在")
+        }
+        if (file.length() > maxBytes) {
+            return sendMessage("截图发送失败：图片超过2MB限制（当前 ${file.length() / 1024}KB），请截图后手动查看")
+        }
+
+        val imageBytes = file.readBytes()
 
         // 计算 Base64
         val base64 = Base64.getEncoder().encodeToString(imageBytes)

--- a/app/src/main/java/com/pengxh/daily/app/ui/MainActivity.kt
+++ b/app/src/main/java/com/pengxh/daily/app/ui/MainActivity.kt
@@ -136,7 +136,7 @@ class MainActivity : KotlinBaseActivity<ActivityMainBinding>(), TaskScheduler.Ta
         binding.toolbar.setOnMenuItemClickListener { menuItem ->
             when (menuItem.itemId) {
                 R.id.menu_add_task -> {
-                    if (taskScheduler.isTaskStarted()) {
+                    if (isTaskStarted) {
                         "任务进行中，无法添加".show(this)
                         return@setOnMenuItemClickListener true
                     }
@@ -176,6 +176,13 @@ class MainActivity : KotlinBaseActivity<ActivityMainBinding>(), TaskScheduler.Ta
 
     override fun initOnCreate(savedInstanceState: Bundle?) {
         EventBus.getDefault().register(this)
+
+        // 处理 Alarm 触发时 Activity 未注册导致的 ResetDailyTask 事件丢失
+        val stickyReset = EventBus.getDefault().getStickyEvent(ApplicationEvent.ResetDailyTask::class.java)
+        if (stickyReset != null) {
+            EventBus.getDefault().removeStickyEvent(stickyReset)
+            taskScheduler.startTask()
+        }
 
         // 显示悬浮窗
         if (Settings.canDrawOverlays(this)) {
@@ -221,6 +228,12 @@ class MainActivity : KotlinBaseActivity<ActivityMainBinding>(), TaskScheduler.Ta
 
         // 检查是否需要执行错过的重置
         checkMissedReset()
+
+        // Activity 重建时，若任务之前在跑，重新启动调度器恢复真实运行状态
+        val wasRunning = SaveKeyValues.getValue(Constant.TASK_RUNNING_STATE_KEY, false) as Boolean
+        if (wasRunning) {
+            taskScheduler.startTask()
+        }
     }
 
     private fun checkMissedReset() {
@@ -267,6 +280,7 @@ class MainActivity : KotlinBaseActivity<ActivityMainBinding>(), TaskScheduler.Ta
             }
 
             is ApplicationEvent.ResetDailyTask -> {
+                EventBus.getDefault().removeStickyEvent(ApplicationEvent.ResetDailyTask)
                 taskScheduler.startTask()
             }
 
@@ -384,6 +398,7 @@ class MainActivity : KotlinBaseActivity<ActivityMainBinding>(), TaskScheduler.Ta
 
     override fun onTaskStarted() {
         isTaskStarted = true
+        SaveKeyValues.putValue(Constant.TASK_RUNNING_STATE_KEY, true)
         binding.executeTaskButton.setIconResource(R.mipmap.ic_stop)
         binding.executeTaskButton.setIconTintResource(R.color.red)
         binding.executeTaskButton.text = "停止"
@@ -392,7 +407,7 @@ class MainActivity : KotlinBaseActivity<ActivityMainBinding>(), TaskScheduler.Ta
 
     override fun onTaskStopped() {
         isTaskStarted = false
-        // 重置UI状态
+        SaveKeyValues.putValue(Constant.TASK_RUNNING_STATE_KEY, false)
         dailyTaskAdapter.updateCurrentTaskState(-1)
         binding.tipsView.text = ""
 
@@ -401,12 +416,10 @@ class MainActivity : KotlinBaseActivity<ActivityMainBinding>(), TaskScheduler.Ta
     }
 
     override fun onTaskCompleted() {
-        // 任务全部完成
-        isTaskStarted = false
+        // 今日完成不等于停止运行，明天还要继续，按钮保持"停止"
+        dailyTaskAdapter.updateCurrentTaskState(-1)
         binding.tipsView.text = "当天所有任务已执行完毕"
         binding.tipsView.setTextColor(R.color.ios_green.convertColor(context))
-        dailyTaskAdapter.updateCurrentTaskState(-1)
-        resetExecuteButton()
         messageDispatcher.sendMessage("任务状态通知", "今日任务已全部执行完毕")
     }
 
@@ -428,6 +441,7 @@ class MainActivity : KotlinBaseActivity<ActivityMainBinding>(), TaskScheduler.Ta
 
     override fun onTaskExecutionError(message: String) {
         isTaskStarted = false
+        SaveKeyValues.putValue(Constant.TASK_RUNNING_STATE_KEY, false)
         resetExecuteButton()
         binding.tipsView.text = message
         binding.tipsView.setTextColor(R.color.red.convertColor(context))
@@ -455,7 +469,7 @@ class MainActivity : KotlinBaseActivity<ActivityMainBinding>(), TaskScheduler.Ta
      * 列表项单击
      * */
     private fun itemClick(position: Int) {
-        if (taskScheduler.isTaskStarted()) {
+        if (isTaskStarted) {
             "任务进行中，无法修改".show(this)
             return
         }
@@ -488,7 +502,7 @@ class MainActivity : KotlinBaseActivity<ActivityMainBinding>(), TaskScheduler.Ta
      * 列表项长按
      * */
     private fun itemLongClick(position: Int) {
-        if (taskScheduler.isTaskStarted()) {
+        if (isTaskStarted) {
             "任务进行中，无法删除".show(this)
             return
         }
@@ -527,7 +541,8 @@ class MainActivity : KotlinBaseActivity<ActivityMainBinding>(), TaskScheduler.Ta
 
     override fun initEvent() {
         binding.executeTaskButton.setOnClickListener {
-            if (taskScheduler.isTaskStarted()) {
+            // 用运行模式标志判断，而非调度器内部状态（任务当天完成后调度器已闲置但仍在运行模式）
+            if (isTaskStarted) {
                 taskScheduler.stopTask()
             } else {
                 if (DatabaseWrapper.loadAllTask().isEmpty()) {

--- a/app/src/main/java/com/pengxh/daily/app/utils/Constant.kt
+++ b/app/src/main/java/com/pengxh/daily/app/utils/Constant.kt
@@ -27,6 +27,7 @@ object Constant {
     const val RESULT_SOURCE_KEY = "RESULT_SOURCE_KEY"
     const val POWER_SAVE_MODE_KEY = "POWER_SAVE_MODE_KEY"
     const val SKIP_CHINA_HOLIDAY_KEY = "SKIP_CHINA_HOLIDAY_KEY"
+    const val TASK_RUNNING_STATE_KEY = "TASK_RUNNING_STATE_KEY"
 
     // ============================================================
     // 目标应用

--- a/app/src/main/java/com/pengxh/daily/app/utils/TaskResetReceiver.kt
+++ b/app/src/main/java/com/pengxh/daily/app/utils/TaskResetReceiver.kt
@@ -21,8 +21,8 @@ class TaskResetReceiver : BroadcastReceiver() {
 
         val autoStart = SaveKeyValues.getValue(Constant.TASK_AUTO_START_KEY, true) as Boolean
         if (autoStart) {
-            // 触发主界面重置任务
-            EventBus.getDefault().post(ApplicationEvent.ResetDailyTask)
+            // 用 postSticky 保证 MainActivity 未注册时事件不丢失，启动后仍可收到
+            EventBus.getDefault().postSticky(ApplicationEvent.ResetDailyTask)
         }
 
         markTodayAsReset()
@@ -43,6 +43,8 @@ class TaskResetReceiver : BroadcastReceiver() {
     private fun markTodayAsReset() {
         val today = dateFormat.format(Date())
         SaveKeyValues.putValue(Constant.LAST_RESET_DATE_KEY, today)
+        // 每日重置时清掉运行状态，防止第二天打开 app 还显示"停止"
+        SaveKeyValues.putValue(Constant.TASK_RUNNING_STATE_KEY, false)
         LogFileManager.writeLog("标记 $today 已重置")
     }
 }


### PR DESCRIPTION
## 问题背景

上一版重构（`c69c99e`）在移除 `DailyTaskController` 时，任务运行状态未做持久化处理，导致 Activity 重建后状态全部丢失，衍生出以下几个问题。

---

## 修复内容

### 1. 任务运行状态持久化

**涉及文件**：`Constant.kt` / `MainActivity.kt` / `TaskResetReceiver.kt`

新增 `TASK_RUNNING_STATE_KEY` 常量，在四个关键节点写入 SharedPreferences：

- `onTaskStarted` → 写 `true`
- `onTaskStopped` / `onTaskExecutionError` → 写 `false`
- `TaskResetReceiver.markTodayAsReset` → 写 `false`（每日重置时清零，防止次日打开仍显示"停止"）

Activity 重建时读取持久化状态，若之前在运行则重新调用 `startTask()` 恢复调度器，保证真实调度状态与 UI 一致。

---

### 2. 修正按钮运行模式逻辑

**涉及文件**：`MainActivity.kt`

**问题**：原代码用 `taskScheduler.isTaskStarted()` 判断按钮状态，但该值在今日任务全部完成后变为 `false`，导致按钮错误回到"启动"状态。

**产品逻辑**：启动即进入持续运行模式，今日任务完成不代表停止运行，明天还要继续跑。只有用户主动点"停止"才退出运行模式。

**改动**：
- `onTaskCompleted()` 不再重置按钮和 `isTaskStarted`，仅更新提示文字
- 按钮点击、菜单添加任务、列表项编辑/删除的可操作判断统一改为使用 `isTaskStarted`（运行模式标志）

---

### 3. 修复 EventBus 事件丢失导致自动启动失败

**涉及文件**：`TaskResetReceiver.kt` / `MainActivity.kt`

**问题**：AlarmManager 触发 `TaskResetReceiver` 时，若 MainActivity 尚未注册 EventBus，原来的 `post()` 会静默丢弃 `ResetDailyTask` 事件，任务当天不会自动启动。

**改动**：改为 `postSticky()`，MainActivity 注册后主动检查并消费 sticky 事件，保证自动启动可靠触发。

---

### 4. 防止发送超大截图导致 OOM 崩溃

**涉及文件**：`RetrofitServiceManager.kt`

**问题**：原代码直接 `readBytes()` 无大小检查，微信群机器人图片上限 2MB，大图一次性读入内存会触发 OOM 崩溃。

**改动**：发送前校验文件存在性与大小，超限时降级发送文字提示，告知用户手动查看结果。

---

### 5. 消除任务列表更新时的闪烁

**涉及文件**：`DailyTaskAdapter.kt`

**问题**：`updateCurrentTaskState` 调用 `notifyDataSetChanged()` 刷新整个列表，每次任务状态变更都触发全量重绘，列表有明显闪烁。

**改动**：改为 `notifyItemChanged()`，只通知发生变化的两项（旧选中项 + 新选中项），消除视觉抖动。

---

## 测试建议

- [ ] 点击"启动"后按钮变为"停止"，今日任务全部执行完毕后按钮保持"停止"
- [ ] 杀掉 App 重新打开，若之前在运行状态，按钮应恢复"停止"并自动重启调度
- [ ] 点击"停止"后按钮变回"启动"，再次打开 App 显示"启动"
- [ ] 发送超过 2MB 的截图时收到文字提示而非崩溃
- [ ] 任务状态切换时列表无闪烁