### PR TITLE
fix: 修复 DT#打卡返回并增加截图开关

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -18,8 +18,8 @@ android {
         applicationId 'com.pengxh.daily.app'
         minSdk 26
         targetSdk 36
-        versionCode 2420
-        versionName '2.4.2.0'
+        versionCode 2421
+        versionName '2.4.2.1'
         ndkVersion '21.4.7075529'
 
         ndk {

--- a/app/src/main/java/com/pengxh/daily/app/service/NotificationMonitorService.kt
+++ b/app/src/main/java/com/pengxh/daily/app/service/NotificationMonitorService.kt
@@ -2,7 +2,6 @@ package com.pengxh.daily.app.service
 
 import android.app.Notification
 import android.content.ComponentName
-import android.os.SystemClock
 import android.provider.Settings
 import android.service.notification.NotificationListenerService
 import android.service.notification.StatusBarNotification
@@ -11,7 +10,6 @@ import com.pengxh.daily.app.extensions.openApplication
 import com.pengxh.daily.app.sqlite.DatabaseWrapper
 import com.pengxh.daily.app.sqlite.bean.NotificationBean
 import com.pengxh.daily.app.utils.Constant
-import com.pengxh.daily.app.utils.FloatingWindowController
 import com.pengxh.daily.app.utils.MessageDispatcher
 import com.pengxh.daily.app.utils.MonitorEvent
 import com.pengxh.daily.app.utils.ProjectionSession
@@ -23,10 +21,8 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.asSharedFlow
-import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 
@@ -208,20 +204,18 @@ class NotificationMonitorService : NotificationListenerService() {
                 // 自定义打卡指令，用户可配置关键词（如 "打卡"），同样需要 DT# 前缀
                 val key = SaveKeyValues.loadString(Constant.REMOTE_COMMAND_KEY, "打卡")
                 if (notice.contains(key)) {
-                    // 遥控"打卡"：一次性，只唤起目标 App 并倒计时，不关联任务调度
+                    val timeoutSeconds = SaveKeyValues.loadInt(
+                        Constant.STAY_OVERTIME_KEY, Constant.DEFAULT_OVER_TIME
+                    )
+                    val returnScreenshot = SaveKeyValues.loadBoolean(
+                        Constant.REMOTE_CLOCK_IN_CAPTURE_KEY, false
+                    )
                     openApplication {
-                        serviceScope.launch {
-                            val timeoutSeconds = SaveKeyValues.loadInt(
-                                Constant.STAY_OVERTIME_KEY, Constant.DEFAULT_OVER_TIME
+                        emitMonitorEvent(
+                            MonitorEvent.AppOpenedForRemoteClockIn(
+                                timeoutSeconds, returnScreenshot
                             )
-                            val target = SystemClock.elapsedRealtime() + timeoutSeconds * 1000L
-                            while (isActive) {
-                                val remaining = target - SystemClock.elapsedRealtime()
-                                if (remaining <= 0) break
-                                FloatingWindowController.updateTime((remaining / 1000).toInt())
-                                delay(minOf(1000L, remaining).coerceAtLeast(1))
-                            }
-                        }
+                        )
                     }
                 }
             }

--- a/app/src/main/java/com/pengxh/daily/app/ui/MainActivity.kt
+++ b/app/src/main/java/com/pengxh/daily/app/ui/MainActivity.kt
@@ -375,41 +375,69 @@ class MainActivity : KotlinBaseActivity<ActivityMainBinding>() {
             }
 
             is MonitorEvent.AppOpenedForScreenshot -> {
-                /**
-                 * 遥控"截屏"指令完整流程：
-                 *   1. 由 NotificationMonitorService 触发 openApplication
-                 *   2. 等待 10 秒让目标 App 界面稳定（需要把目标APP的启动动画耗时加上）
-                 *   3. 触发截屏
-                 *   4. 等待截屏结果（在跳转之前，避免 lifecycle 问题）
-                 *   5. 跳回 MainActivity
-                 *   6. 发送通知
-                 */
-                lifecycleScope.launch {
-                    // 倒计时 10 秒，更新悬浮窗
-                    val countdownTarget = SystemClock.elapsedRealtime() + 10_000L
-                    while (true) {
-                        val remaining = countdownTarget - SystemClock.elapsedRealtime()
-                        if (remaining <= 0) break
-                        FloatingWindowController.updateTime((remaining / 1000).toInt())
-                        delay(minOf(1000L, remaining).coerceAtLeast(1))
-                    }
+                captureTargetAppAndReturn(
+                    countdownSeconds = 10,
+                    messageTitle = "截屏状态通知",
+                    successMessage = "截图完成",
+                    failureMessage = "截图完成，但是无法获取截图"
+                )
+            }
 
-                    // 触发截屏并等待截屏结果
-                    val imagePath = CaptureImageService.requestCaptureScreen().await()
-
-                    // 回到主界面
-                    backToMainActivity()
-
-                    // 发送通知（跳回后执行，Activity 已在前台）
-                    if (imagePath.isNullOrEmpty()) {
-                        MessageDispatcher.sendMessage("截屏状态通知", "截图完成，但是无法获取截图")
-                    } else {
-                        MessageDispatcher.sendAttachmentMessage(
-                            "截屏状态通知", "截图完成", imagePath
-                        )
-                    }
+            is MonitorEvent.AppOpenedForRemoteClockIn -> {
+                if (event.returnScreenshot) {
+                    captureTargetAppAndReturn(
+                        countdownSeconds = event.countdownSeconds,
+                        messageTitle = "打卡结果通知",
+                        successMessage = "打卡完成，结果见附件",
+                        failureMessage = "打卡完成，但是无法获取截图"
+                    )
+                } else {
+                    returnAfterCountdown(event.countdownSeconds)
                 }
             }
+        }
+    }
+
+    private fun returnAfterCountdown(countdownSeconds: Int) {
+        lifecycleScope.launch {
+            countdownTargetApp(countdownSeconds)
+            backToMainActivity()
+        }
+    }
+
+    /**
+     * 远程截屏与远程打卡的公共流程：倒计时 → 截屏 → 返回 → 发送结果。
+     */
+    private fun captureTargetAppAndReturn(
+        countdownSeconds: Int,
+        messageTitle: String,
+        successMessage: String,
+        failureMessage: String
+    ) {
+        lifecycleScope.launch {
+            countdownTargetApp(countdownSeconds)
+
+            // 在返回前等待截屏结果，避免 Activity 生命周期变化导致结果丢失。
+            val imagePath = CaptureImageService.requestCaptureScreen().await()
+            backToMainActivity()
+
+            if (imagePath.isNullOrEmpty()) {
+                MessageDispatcher.sendMessage(messageTitle, failureMessage)
+            } else {
+                MessageDispatcher.sendAttachmentMessage(
+                    messageTitle, successMessage, imagePath
+                )
+            }
+        }
+    }
+
+    private suspend fun countdownTargetApp(countdownSeconds: Int) {
+        val countdownTarget = SystemClock.elapsedRealtime() + countdownSeconds * 1000L
+        while (true) {
+            val remaining = countdownTarget - SystemClock.elapsedRealtime()
+            if (remaining <= 0) break
+            FloatingWindowController.updateTime((remaining / 1000).toInt())
+            delay(minOf(1000L, remaining).coerceAtLeast(1))
         }
     }
 

--- a/app/src/main/java/com/pengxh/daily/app/ui/SettingsActivity.kt
+++ b/app/src/main/java/com/pengxh/daily/app/ui/SettingsActivity.kt
@@ -360,6 +360,20 @@ class SettingsActivity : KotlinBaseActivity<ActivitySettingsBinding>() {
             SaveKeyValues.saveBoolean(Constant.POWER_SAVE_MODE_KEY, isChecked)
         }
 
+        binding.remoteClockInCaptureSwitch.setOnCheckedChangeListener { _, isChecked ->
+            if (syncingSwitchState) {
+                return@setOnCheckedChangeListener
+            }
+            if (isChecked && !ProjectionSession.isStateActive()) {
+                syncingSwitchState = true
+                binding.remoteClockInCaptureSwitch.isChecked = false
+                syncingSwitchState = false
+                "请先打开截屏服务".show(this)
+                return@setOnCheckedChangeListener
+            }
+            SaveKeyValues.saveBoolean(Constant.REMOTE_CLOCK_IN_CAPTURE_KEY, isChecked)
+        }
+
         binding.introduceLayout.setOnClickListener {
             navigatePageTo<QuestionAndAnswerActivity>()
         }
@@ -484,6 +498,8 @@ class SettingsActivity : KotlinBaseActivity<ActivitySettingsBinding>() {
                 SaveKeyValues.loadBoolean(Constant.BACK_TO_HOME_KEY, false)
             binding.powerSaveSwitch.isChecked =
                 SaveKeyValues.loadBoolean(Constant.POWER_SAVE_MODE_KEY, false)
+            binding.remoteClockInCaptureSwitch.isChecked =
+                SaveKeyValues.loadBoolean(Constant.REMOTE_CLOCK_IN_CAPTURE_KEY, false)
         } finally {
             syncingSwitchState = false
         }

--- a/app/src/main/java/com/pengxh/daily/app/utils/Constant.kt
+++ b/app/src/main/java/com/pengxh/daily/app/utils/Constant.kt
@@ -28,6 +28,8 @@ object Constant {
     const val RANDOM_TIME_KEY = "RANDOM_TIME_KEY" // 随机时间(Boolean)
     const val SKIP_HOLIDAY_KEY = "SKIP_HOLIDAY_KEY" // 跳过节假日(Boolean)
     const val POWER_SAVE_MODE_KEY = "POWER_SAVE_MODE_KEY" // 省电模式(Boolean)
+    const val REMOTE_CLOCK_IN_CAPTURE_KEY =
+        "REMOTE_CLOCK_IN_CAPTURE_KEY" // 远程打卡指令返回截图(Boolean)
 
     // 不导出的sp缓存
     const val LAST_RESET_DATE_KEY = "LAST_RESET_DATE_KEY"

--- a/app/src/main/java/com/pengxh/daily/app/utils/MonitorEvent.kt
+++ b/app/src/main/java/com/pengxh/daily/app/utils/MonitorEvent.kt
@@ -34,4 +34,12 @@ sealed class MonitorEvent {
      * 远程"截屏"指令
      * */
     data object AppOpenedForScreenshot : MonitorEvent()
+
+    /**
+     * 目标应用已为远程"打卡"指令打开
+     * */
+    data class AppOpenedForRemoteClockIn(
+        val countdownSeconds: Int,
+        val returnScreenshot: Boolean
+    ) : MonitorEvent()
 }

--- a/app/src/main/res/layout/activity_settings.xml
+++ b/app/src/main/res/layout/activity_settings.xml
@@ -98,6 +98,48 @@
                     android:background="@drawable/bg_solid_layout_white_16"
                     android:paddingHorizontal="@dimen/dp_16">
 
+                    <LinearLayout
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_centerVertical="true"
+                        android:layout_marginEnd="@dimen/dp_72"
+                        android:orientation="vertical">
+
+                        <com.google.android.material.textview.MaterialTextView
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:text="远程打卡返回截图"
+                            android:textAppearance="@style/TextAppearance.Material3.TitleSmall" />
+
+                        <com.google.android.material.textview.MaterialTextView
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            android:layout_marginTop="@dimen/dp_4"
+                            android:singleLine="true"
+                            android:text="开启后，DT#打卡倒计时结束会截屏并发送结果"
+                            android:textSize="@dimen/sp_10" />
+                    </LinearLayout>
+
+                    <com.google.android.material.switchmaterial.SwitchMaterial
+                        android:id="@+id/remoteClockInCaptureSwitch"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_alignParentEnd="true"
+                        android:layout_centerVertical="true" />
+                </RelativeLayout>
+
+                <View
+                    android:layout_width="match_parent"
+                    android:layout_height="1px"
+                    android:layout_marginHorizontal="@dimen/dp_16"
+                    android:background="#CCC" />
+
+                <RelativeLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="@dimen/itemLayoutHeight"
+                    android:background="@drawable/bg_solid_layout_white_16"
+                    android:paddingHorizontal="@dimen/dp_16">
+
                     <com.google.android.material.textview.MaterialTextView
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"


### PR DESCRIPTION
## 改动内容

- 修复 `DT#打卡` 倒计时结束后停留在目标应用、未返回 DailyTask 的问题。
- 新增“远程打卡返回截图”开关，默认关闭：
  - 关闭时，`DT#打卡` 倒计时结束后仅返回 DailyTask。
  - 开启时，倒计时结束后截屏、返回 DailyTask，并通过已配置的消息渠道发送图片。
- 复用 `DT#截屏` 已有的倒计时、截屏、返回和发送结果流程。
- 版本号升级至 `2.4.2.1`（versionCode 2421）。

## 问题原因

协程重构后，远程打卡指令只负责打开目标应用并执行倒计时。倒计时循环退出后没有触发返回事件，因此悬浮窗归零后手机仍停留在目标应用。

## 用户影响

`DT#打卡` 现在会在配置的停留时间结束后稳定返回 DailyTask。用户可以按需决定是否同时获取并发送打卡截图；默认行为不会额外截屏。

## 验证

- `:app:assembleRelease` 构建成功。
- Release lint 检查通过。
- Release APK v2 签名验证通过。
- 已通过 ADB 覆盖安装到 Android 真机（SM-S9110），版本信息确认为 2.4.2.1 / 2421。
